### PR TITLE
Remove `each()` function call which is removed as of PHP 8

### DIFF
--- a/admin/dropdown.php
+++ b/admin/dropdown.php
@@ -45,9 +45,9 @@ abstract class P2P_Dropdown {
 
 		$tmp = reset( $_GET['p2p'] );
 
-		$args['connected_type'] = key( $_GET['p2p'] );
-
-		list( $args['connected_direction'], $args['connected_items'] ) = each( $tmp );
+		$args['connected_type']      = key( $_GET['p2p'] );
+		$args['connected_direction'] = key( $tmp );
+		$args['connected_items']     = current( $tmp );
 
 		if ( !$args['connected_items'] )
 			return array();


### PR DESCRIPTION
This should resolve https://wordpress.org/support/topic/php-8-fatal-error-11/

Located through a PHPCompatibility check.

```
FILE: wp-content/plugins/posts-to-posts/admin/dropdown.php
----------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------------------------
 50 | WARNING | Function each() is deprecated since PHP 7.2; Use a foreach loop instead
----------------------------------------------------------------------------------------
```

**WARNING** This PR has NOT been tested, this change is purely replacing the [each()](https://www.php.net/each) function which has been removed in PHP 8.0 with what I believe is the equivalent.