### PR TITLE
Remove .idea folder and CONTRIBUTING.md from plugin distribution

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.wordpress-org
 /.git
 /.github
+/.idea
 .distignore
 .gitattributes
 .editorconfig
@@ -16,6 +17,7 @@ bin
 circle.yml
 composer.json
 composer.lock
+CONTRIBUTING.md
 Gruntfile.js
 package.json
 phpunit.xml


### PR DESCRIPTION
I noticed that these dev files are included in the WP plugin zip, adding them to the `.distignore` file should fix this.